### PR TITLE
Fix enemy script

### DIFF
--- a/Enemy/Enemy.gd
+++ b/Enemy/Enemy.gd
@@ -10,31 +10,29 @@ var direction=1
 
 var is_dead = false
 var timeout_flag = 0
-signal player_in_contact(damage)
+signal player_in_contact(damage)	
 
 func _physics_process(delta):
 	if is_dead == false:
 		velocity.x = speed * direction
 		velocity.y += GRAVITY
-#		velocity = move_and_slide(velocity, FLOOR)
-		var collision = move_and_collide(velocity * delta)
-		if collision:
-			velocity = velocity.slide(collision.normal)
-			if collision.collider.name == "Player" :
+		velocity = move_and_slide(velocity, Vector2(0, -1))
+		for i in get_slide_count():
+			var collision = get_slide_collision(i)
+			if collision.collider.is_in_group("player"):
 				if timeout_flag == 0 :
 					$PlayerHit.start()
 					timeout_flag = 1
-			if collision.collider.name == "Bullet" :
-				print(collision.collider.name)
+			elif collision.collider.name == "Bullet" :
 				On_hit_and_dead()
+			elif collision.normal.y == 0:
+				direction *= -1
+				$RayCast2D.position.x *= -1
+			
 	if direction == 1:
 		$Sprite.flip_h == false
 	else:
 		$Sprite.flip_h == true
-		
-	if is_on_wall():
-		direction *= -1
-		$RayCast2D.position.x *= -1
 		
 	if $RayCast2D.is_colliding() == false:
 		direction *= -1
@@ -53,5 +51,5 @@ func _on_Timer_timeout():
 	queue_free()
 
 func _on_PlayerHit_timeout():
-	emit_signal("player_in_contact",5)
+	get_tree().call_group("player", "enemy_in_contact", 5)
 	timeout_flag = 0

--- a/Interface/Interface.gd
+++ b/Interface/Interface.gd
@@ -1,6 +1,4 @@
 extends Control
 
-signal health_changed(new_health)
-
 func _on_Player_health_changed(new_health):
-	emit_signal("health_changed",new_health)
+	$Lifebar/TextureProgress.value = new_health

--- a/Interface/Interface.tscn
+++ b/Interface/Interface.tscn
@@ -1,10 +1,9 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://Interface/Health_fill.png" type="Texture" id=1]
 [ext_resource path="res://Interface/Health_BG.png" type="Texture" id=2]
 [ext_resource path="res://Interface/label_HP.png" type="Texture" id=3]
 [ext_resource path="res://Interface/Interface.gd" type="Script" id=4]
-[ext_resource path="res://Interface/Lifebar.gd" type="Script" id=5]
 
 [node name="Interface" type="Control"]
 anchor_right = 1.0
@@ -20,7 +19,6 @@ margin_top = 29.0
 margin_right = 513.0
 margin_bottom = 82.0
 rect_scale = Vector2( 0.5, 0.5 )
-script = ExtResource( 5 )
 __meta__ = {
 "_edit_use_anchors_": false
 }
@@ -43,4 +41,3 @@ margin_bottom = 53.0
 value = 100.0
 texture_under = ExtResource( 2 )
 texture_progress = ExtResource( 1 )
-[connection signal="health_changed" from="." to="Lifebar" method="_on_Interface_health_changed"]

--- a/Player/player.gd
+++ b/Player/player.gd
@@ -84,6 +84,6 @@ func _shoot() :
 		bullet.set_position(bullet_pos)
 
 
-func _on_Enemy_player_in_contact(damage):
-	set_health(health-damage)
-	emit_signal("health_changed",health)
+func enemy_in_contact(damage):
+	set_health(health - damage)
+	emit_signal("health_changed", health)

--- a/Scenes/level1.tscn
+++ b/Scenes/level1.tscn
@@ -58,10 +58,9 @@ margin_right = -7.0
 margin_bottom = -9.0
 rect_scale = Vector2( 0.75, 0.75 )
 
-[node name="Lifebar" parent="Interface" index="0"]
-script = null
-
-[node name="Player" parent="." instance=ExtResource( 3 )]
+[node name="Player" parent="." groups=[
+"player",
+] instance=ExtResource( 3 )]
 position = Vector2( 32.5245, 124.371 )
 scale = Vector2( 0.15, 0.15 )
 
@@ -70,64 +69,17 @@ frame = 9
 
 [node name="Enemy" parent="." instance=ExtResource( 5 )]
 position = Vector2( 414.593, 207.053 )
-
-[node name="Enemy2" parent="." groups=[
-"enemy",
-] instance=ExtResource( 5 )]
-position = Vector2( 200.612, 190.842 )
-
-[node name="CollisionShape2D" parent="Enemy2" index="1"]
-position = Vector2( 0, 2.16144 )
-
-[node name="Enemy3" parent="." groups=[
-"enemy",
-] instance=ExtResource( 5 )]
-position = Vector2( 577.432, 318.881 )
-
-[node name="CollisionShape2D" parent="Enemy3" index="1"]
-position = Vector2( 0, 2.16144 )
-
-[node name="Enemy4" parent="." instance=ExtResource( 5 )]
-position = Vector2( 608.613, 240.599 )
-
-[node name="CollisionShape2D" parent="Enemy4" index="1"]
-position = Vector2( 0, 2.16144 )
-
-[node name="Enemy5" parent="." instance=ExtResource( 5 )]
-position = Vector2( 235.11, 270.452 )
-
-[node name="CollisionShape2D" parent="Enemy5" index="1"]
-position = Vector2( 0, 2.16144 )
-
-[node name="Enemy6" parent="." instance=ExtResource( 5 )]
-position = Vector2( 132.944, 129.145 )
-
-[node name="CollisionShape2D" parent="Enemy6" index="1"]
-position = Vector2( 0, 2.16144 )
-
-[node name="Enemy7" parent="." instance=ExtResource( 5 )]
-position = Vector2( 92.4755, 318.881 )
-
-[node name="CollisionShape2D" parent="Enemy7" index="1"]
-position = Vector2( 0, 2.16144 )
-
-[node name="Enemy8" parent="." instance=ExtResource( 5 )]
-position = Vector2( 333.295, 318.881 )
-
-[node name="CollisionShape2D" parent="Enemy8" index="1"]
-position = Vector2( 0, 2.16144 )
+speed = 40
 
 [node name="Bullet" parent="." instance=ExtResource( 7 )]
 
 [node name="Control" parent="." instance=ExtResource( 6 )]
+visible = false
+
+[node name="Enemy2" parent="." instance=ExtResource( 5 )]
+position = Vector2( 150, 110 )
+[connection signal="health_changed" from="Player" to="Interface" method="_on_Player_health_changed"]
 [connection signal="player_in_contact" from="Enemy" to="Player" method="_on_Enemy_player_in_contact"]
-[connection signal="player_in_contact" from="Enemy2" to="Player" method="_on_Enemy_player_in_contact"]
-[connection signal="player_in_contact" from="Enemy3" to="Player" method="_on_Enemy_player_in_contact"]
-[connection signal="player_in_contact" from="Enemy4" to="Player" method="_on_Enemy_player_in_contact"]
-[connection signal="player_in_contact" from="Enemy5" to="Player" method="_on_Enemy_player_in_contact"]
-[connection signal="player_in_contact" from="Enemy6" to="Player" method="_on_Enemy_player_in_contact"]
-[connection signal="player_in_contact" from="Enemy7" to="Player" method="_on_Enemy_player_in_contact"]
-[connection signal="player_in_contact" from="Enemy8" to="Player" method="_on_Enemy_player_in_contact"]
 
 [editable path="Interface"]
 
@@ -136,15 +88,3 @@ position = Vector2( 0, 2.16144 )
 [editable path="Enemy"]
 
 [editable path="Enemy2"]
-
-[editable path="Enemy3"]
-
-[editable path="Enemy4"]
-
-[editable path="Enemy5"]
-
-[editable path="Enemy6"]
-
-[editable path="Enemy7"]
-
-[editable path="Enemy8"]


### PR DESCRIPTION
- Use `move_and_slide` instead of `move_and_collide` as the second one only allows for one collision. Read [this](https://docs.godotengine.org/en/stable/tutorials/physics/using_kinematic_body_2d.html) for more information on movement
- Iterate through all these colliders, otherwise you were only getting the floor collider before
- Add enemies using the link-shaped button like [this](https://docs.godotengine.org/en/stable/getting_started/step_by_step/instancing.html)
- I've also removed some enemies, you can add them in later
- Enemy damage is done using `get_tree().call_group()` on a new player group. More information [here](https://docs.godotengine.org/en/stable/getting_started/step_by_step/scripting_continued.html#groups). This is because apparently I needed to add a new signal receiving method for every single enemy
- Hook up the `health_changed` signal directly to `Interface.gd`, which simplified UI programming a lot